### PR TITLE
Remove useless <turbo-echo-stream-source> when viewing post

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,7 +1,5 @@
 <x-app-layout>
     <turbo-echo-stream-source channel="App.Models.Post.{{ $post->id }}"></turbo-echo-stream-source>
-    <turbo-echo-stream-source
-        channel="App.Models.Team.{{ auth()->user()->currentTeam->id }}"></turbo-echo-stream-source>
 
     <x-slot name="header">
         <a href="{{ route('posts.index') }}"


### PR DESCRIPTION
Tested with multiple users and updating a post works fine without this `<turbo-echo-stream-source>`

Because the previous `<turbo-echo-stream-source>` already do the job 👍

NB: This extra  `<turbo-echo-stream-source>` was added in the pull request #2, but with this commit https://github.com/tonysm/turbo-demo-app/commit/9ca6da768e9b3052031e388b28cddc699bfe7778#diff-c7c399393ea36f8fc73996a0b34b8910ff2253961f8384883ba34ab032e1872eR27 it's now useless 😅